### PR TITLE
Added academic calendar feature

### DIFF
--- a/nouapp/templates/academic_calendar.html
+++ b/nouapp/templates/academic_calendar.html
@@ -1,0 +1,703 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Academic Calendar – Assignments, Exams, Announcements</title>
+    <style>
+        :root {
+            --bg: #ffffff;
+            --panel: #000000eb;
+            --muted: #ffffff;
+            --text: #000000;
+            --accent: #dae2da;
+            --border: #ffffff;
+            --assignment: #55d67a;
+            --exam: #ff6a6a;
+            --announce: #f7c948;
+        }
+
+        * {
+            box-sizing: border-box
+        }
+
+        html,
+        body {
+            height: 100%
+        }
+
+        body {
+            margin: 0;
+            background: white;
+            color: var(--text);
+            font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            padding: 16px;
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap
+        }
+
+        h1 {
+            font-size: 18px;
+            margin: 0;
+            letter-spacing: .2px
+        }
+
+        .controls {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+            flex-wrap: wrap
+        }
+
+        button,
+        select,
+        input,
+        textarea {
+            background: var(--panel);
+            color: var(--text);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 8px 10px;
+            outline: none;
+        }
+
+        button {
+            cursor: pointer
+        }
+
+        button.ghost {
+            background: transparent
+        }
+
+        .legend {
+            display: flex;
+            gap: 10px;
+            margin-left: auto;
+            flex-wrap: wrap
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 10px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: #dee3e3;
+            font-size: 12px
+        }
+
+        .dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%
+        }
+
+        .dot.assignment {
+            background: var(--assignment)
+        }
+
+        .dot.exam {
+            background: var(--exam)
+        }
+
+        .dot.announcement {
+            background: var(--announce)
+        }
+
+        main {
+            display: grid;
+            grid-template-columns: 1.2fr .8fr;
+            gap: 14px
+        }
+
+        @media (max-width: 950px) {
+            main {
+                grid-template-columns: 1fr
+            }
+        }
+
+        /* Calendar grid */
+        .calendar {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 10px;
+        }
+
+        .cal-head {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 6px 4px 10px
+        }
+
+        .month-title {
+            font-weight: 700;
+            letter-spacing: .3px
+        }
+
+        .weekday-row,
+        .day-grid {
+            display: grid;
+            grid-template-columns: repeat(7, 1fr);
+            gap: 6px
+        }
+
+        .weekday {
+            text-align: center;
+            color: var(--muted);
+            font-size: 12px;
+            padding: 6px 0
+        }
+
+        .day {
+            min-height: 92px;
+            background: #b2b2b3;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 6px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            position: relative;
+        }
+
+        .day.other {
+            opacity: .35
+        }
+
+        .date-num {
+            font-size: 12px;
+            color: var(--muted)
+        }
+
+        .today .date-num {
+            color: #fff;
+            font-weight: 700
+        }
+
+        .tag {
+            font-size: 11px;
+            line-height: 1;
+            padding: 4px 6px;
+            border-radius: 6px;
+            border: 1px solid #0003;
+            width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .tag.assignment {
+            /* background: color-mix(in oklab, var(--assignment), #000 80%) */
+            background: #55d67a;
+        }
+
+        .tag.exam {
+            /* background: color-mix(in oklab, var(--exam), #000 80%) */
+            background: #ff6a6a;
+        }
+
+        .tag.announcement {
+            /* background: color-mix(in oklab, var(--announce), #000 80%) */
+            background: #ffbb00;
+        }
+
+        .fab {
+            position: absolute;
+            inset: auto 10px 10px auto;
+            width: 34px;
+            height: 34px;
+            border-radius: 50%;
+            background: var(--accent);
+            border: none;
+            color: #070c1a;
+            font-weight: 800;
+            cursor: pointer
+        }
+
+        /* Right side */
+        .side {
+            display: grid;
+            gap: 14px
+        }
+
+        .panel {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 12px;
+        }
+
+        .panel h3 {
+            margin: .2rem 0 .7rem;
+            font-size: 14px;
+            color: #ff0000;
+        }
+
+        .list {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            max-height: 340px;
+            overflow: auto
+        }
+
+        .item {
+            border: 1px dashed var(--border);
+            border-radius: 10px;
+            padding: 10px;
+            display: grid;
+            gap: 6px;
+            color: #ffd4d4;
+        }
+
+        .meta {
+            font-size: 12px;
+            color: #847878;
+        }
+
+        .muted{
+            color: #ffffff;
+        }
+
+        .actions {
+            display: flex;
+            gap: 8px;
+        }
+
+        .actions button{
+            color: #ffffff;
+            background: #000000;
+        }
+        
+        .actions button:hover{
+            color: #000000;
+            background: #ffffff;
+        }
+
+        .filters {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap
+        }
+
+        /* Dialog box */
+        dialog {
+            border: none;
+            border-radius: 14px;
+            padding: 0;
+            background: transparent;
+            width: min(520px, 92vw);
+            color: #ffffff;
+        }
+
+        .sheet {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            padding: 14px;
+            border-radius: 14px
+        }
+
+        .row select,input,textarea{
+            color: #000000;
+            background: #d6d6d6;
+        }
+        
+        #cancel,.primary{
+            color: #000000;
+            background: #d6d6d6;
+        }
+
+        #cancel,.primary:hover{
+            color: #000000;
+            background: #ffffff;
+        }
+
+        .row button{
+            color: #ffffff;
+            background: #000000;
+        }
+        
+        .row button:hover{
+            color: #000000;
+            background: #ffffff;
+        }
+
+        form.grid {
+            display: grid;
+            gap: 10px
+        }
+
+        .row {
+            display: grid;
+            gap: 10px;
+            grid-template-columns: 1fr 1fr
+        }
+
+        @media (max-width:520px) {
+            .row {
+                grid-template-columns: 1fr
+            }
+        }
+
+        textarea {
+            min-height: 80px;
+            resize: vertical
+        }
+
+        /* Tiny helpers */
+        .spacer {
+            flex: 1
+        }
+
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            margin: -1px;
+            border: 0;
+            padding: 0;
+            white-space: nowrap;
+            clip-path: inset(50%);
+            overflow: hidden
+        }
+    </style>
+</head>
+
+<body>
+    <header>
+        <h1>Academic Calendar</h1>
+        <div class="controls">
+            <button id="prev" class="ghost" title="Previous month">◀</button>
+            <div id="monthLabel" class="pill"><strong class="month-title"></strong></div>
+            <button id="next" class="ghost" title="Next month">▶</button>
+            <button id="todayBtn" class="ghost">Today</button>
+            <div class="filters">
+                <label class="pill"><input type="checkbox" id="fAssign" checked> Assignments</label>
+                <label class="pill"><input type="checkbox" id="fExam" checked> Exams</label>
+                <label class="pill"><input type="checkbox" id="fAnn" checked> Announcements</label>
+            </div>
+            <button id="addQuick" class="primary">+ Add</button>
+            <button id="seed" class="ghost" title="Load sample data">Load Samples</button>
+            <button id="clearAll" class="ghost" title="Clear all data">Reset</button>
+        </div>
+        <div class="legend">
+            <span class="pill"><span class="dot assignment"></span> Assignment</span>
+            <span class="pill"><span class="dot exam"></span> Exam</span>
+            <span class="pill"><span class="dot announcement"></span> Announcement</span>
+        </div>
+    </header>
+
+    <main>
+        <section class="calendar panel">
+            <div class="cal-head"><span class="muted">Click a day to add</span></div>
+            <div class="weekday-row" id="wk"></div>
+            <div class="day-grid" id="grid" aria-live="polite" aria-busy="false"></div>
+        </section>
+
+        <aside class="side">
+            <section class="panel">
+                <h3>Upcoming (next 30 days)</h3>
+                <div id="upcoming" class="list"></div>
+            </section>
+            <section class="panel">
+                <h3>Announcements (this month)</h3>
+                <div id="annList" class="list"></div>
+            </section>
+        </aside>
+    </main>
+
+    <dialog id="dlg">
+        <div class="sheet">
+            <form id="eventForm" class="grid">
+                <div class="row">
+                    <div>
+                        <legend>Type</legend>
+                        <select name="type" required>
+                            <option value="assignment">Assignment</option>
+                            <option value="exam">Exam</option>
+                            <option value="announcement">Announcement</option>
+                        </select>
+                    </div>
+                    <div>
+                        <legend>Date</legend>
+                        <input type="date" name="date" required />
+                    </div>
+                </div>
+                <div class="row">
+                    <div>
+                        <legend>Time</legend>
+                        <input type="time" name="time" />
+                    </div>
+                    <div>
+                        <legend>Course/ Tags</legend>
+                        <input type="text" name="course" placeholder="e.g., DBMS, COA"  />
+                    </div>
+                </div>
+                <div>
+                    <legend>Title</legend>
+                    <input type="text" name="title" placeholder="Short title" required />
+                </div>
+                <div>
+                    <legend>Details</legend>
+                    <textarea name="desc" placeholder="Any notes…"></textarea>
+                </div>
+                <input type="hidden" name="id" />
+                <div style="display:flex; gap:8px; justify-content:flex-end">
+                    <button type="button" id="cancel">Cancel</button>
+                    <button type="submit" class="primary">Save</button>
+                </div>
+            </form>
+        </div>
+    </dialog>
+
+    <script>
+        /* === Utilities === */
+        const $ = (sel, el = document) => el.querySelector(sel);
+        const $$ = (sel, el = document) => [...el.querySelectorAll(sel)];
+        const fmt = (d) => new Date(d).toISOString().slice(0, 10);
+        const KEY = "acadCalendar.v1";
+        const today = new Date();
+        let state = {
+            year: today.getFullYear(),
+            month: today.getMonth(),
+            filters: { assignment: true, exam: true, announcement: true },
+            events: load()
+        };
+
+        /* === Storage === */
+        function load() {
+            try { return JSON.parse(localStorage.getItem(KEY)) || []; }
+            catch { return []; }
+        }
+        function save() { localStorage.setItem(KEY, JSON.stringify(state.events)); }
+
+        /* === Calendar render === */
+        const MONTHS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+        const WK = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+        function renderWeekdays() {
+            const wk = $("#wk"); wk.innerHTML = "";
+            WK.forEach(w => {
+                const el = document.createElement("div");
+                el.className = "weekday";
+                el.textContent = w;
+                wk.appendChild(el);
+            });
+        }
+        renderWeekdays();
+
+        function daysInMonth(y, m) { return new Date(y, m + 1, 0).getDate(); }
+
+        function renderCalendar() {
+            $(".month-title").textContent = `${MONTHS[state.month]} ${state.year}`;
+            const grid = $("#grid");
+            grid.innerHTML = "";
+            const first = new Date(state.year, state.month, 1);
+            const startDay = first.getDay();
+            // 6 rows * 7 days (keeps grid stable)
+            const total = 42;
+            const prevLast = new Date(state.year, state.month, 0).getDate();
+
+            const monthDays = daysInMonth(state.year, state.month);
+            const todayKey = fmt(new Date());
+
+            for (let i = 0; i < total; i++) {
+                const cell = document.createElement("button");
+                cell.type = "button";
+                cell.className = "day";
+                let dateNum, dateObj, isOther = false;
+
+                if (i < startDay) {
+                    dateNum = prevLast - startDay + i + 1;
+                    dateObj = new Date(state.year, state.month - 1, dateNum);
+                    isOther = true;
+                } else if (i >= startDay + monthDays) {
+                    dateNum = i - (startDay + monthDays) + 1;
+                    dateObj = new Date(state.year, state.month + 1, dateNum);
+                    isOther = true;
+                } else {
+                    dateNum = i - startDay + 1;
+                    dateObj = new Date(state.year, state.month, dateNum);
+                }
+
+                cell.classList.toggle("other", isOther);
+                cell.classList.toggle("today", fmt(dateObj) === todayKey);
+                cell.setAttribute("data-date", fmt(dateObj));
+
+                const head = document.createElement("div");
+                head.className = "date-num";
+                head.textContent = dateNum;
+                cell.appendChild(head);
+
+                // events tags
+                const events = filteredEvents().filter(e => e.date === fmt(dateObj));
+                for (const e of events.slice(0, 3)) {
+                    const tag = document.createElement("div");
+                    tag.className = `tag ${e.type}`;
+                    tag.title = e.title;
+                    tag.textContent = `${iconFor(e.type)} ${e.title}`;
+                    cell.appendChild(tag);
+                }
+                if (events.length > 3) {
+                    const more = document.createElement("div");
+                    more.className = "muted"; more.style.fontSize = "11px";
+                    more.textContent = `+${events.length - 3} more`;
+                    cell.appendChild(more);
+                }
+
+                cell.addEventListener("click", () => openForm({ date: fmt(dateObj) }));
+                grid.appendChild(cell);
+            }
+            renderSidebars();
+        }
+
+        function filteredEvents() {
+            return state.events.filter(e => state.filters[e.type]);
+        }
+
+        function renderSidebars() {
+            const now = new Date();
+            const limit = new Date(); limit.setDate(now.getDate() + 30);
+            const upcoming = filteredEvents()
+                .filter(e => new Date(e.date) >= new Date(fmt(now)) && new Date(e.date) <= limit)
+                .sort((a, b) => new Date(a.date) - new Date(b.date) || a.type.localeCompare(b.type));
+
+            const list = $("#upcoming"); list.innerHTML = "";
+            if (!upcoming.length) { list.innerHTML = `<div class="muted">No items in the next 30 days.</div>`; }
+            for (const e of upcoming) {
+                list.appendChild(itemCard(e));
+            }
+
+            const start = new Date(state.year, state.month, 1);
+            const end = new Date(state.year, state.month + 1, 0);
+            const anns = filteredEvents().filter(e => e.type === "announcement" && new Date(e.date) >= start && new Date(e.date) <= end)
+                .sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            const annList = $("#annList"); annList.innerHTML = "";
+            if (!anns.length) { annList.innerHTML = `<div class="muted">No announcements this month.</div>`; }
+            for (const e of anns) { annList.appendChild(itemCard(e)); }
+        }
+
+        function itemCard(e) {
+            const div = document.createElement("div");
+            div.className = "item";
+            div.innerHTML = `
+    <div><strong>${iconFor(e.type)} ${escapeHtml(e.title)}</strong></div>
+    <div class="meta">${e.course ? `<b>${escapeHtml(e.course)}</b> · ` : ""}${prettyDate(e.date)}${e.time ? ` · ${e.time}` : ""}</div>
+    ${e.desc ? `<div class="muted">${escapeHtml(e.desc)}</div>` : ""}
+    <div class="actions">
+      <button data-act="edit">Edit</button>
+      <button data-act="delete">Delete</button>
+    </div>
+  `;
+            $("button[data-act='edit']", div).onclick = () => openForm(e);
+            $("button[data-act='delete']", div).onclick = () => {
+                if (confirm("Delete this item?")) {
+                    state.events = state.events.filter(x => x.id !== e.id);
+                    save(); renderCalendar();
+                }
+            };
+            return div;
+        }
+
+        function iconFor(t) {
+            return t === "assignment"
+        }
+
+        function prettyDate(s) {
+            const d = new Date(s);
+            return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+        }
+
+        function escapeHtml(s) { return s.replace(/[&<>'"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[c])); }
+
+        /* === Form === */
+        const dlg = $("#dlg");
+        const form = $("#eventForm");
+
+        function openForm(data = {}) {
+            form.reset();
+            form.type.value = data.type || "assignment";
+            form.date.value = data.date || fmt(new Date());
+            form.time.value = data.time || "";
+            form.course.value = data.course || "";
+            form.title.value = data.title || "";
+            form.desc.value = data.desc || "";
+            form.id.value = data.id || "";
+            dlg.showModal();
+        }
+        $("#cancel").onclick = () => dlg.close();
+
+        form.onsubmit = (e) => {
+            e.preventDefault();
+            const payload = Object.fromEntries(new FormData(form).entries());
+            const record = {
+                id: payload.id || crypto.randomUUID(),
+                type: payload.type,
+                date: payload.date,
+                time: payload.time || "",
+                course: payload.course?.trim() || "",
+                title: payload.title.trim(),
+                desc: payload.desc?.trim() || ""
+            };
+            const idx = state.events.findIndex(x => x.id === record.id);
+            if (idx >= 0) state.events[idx] = record;
+            else state.events.push(record);
+            save(); dlg.close(); renderCalendar();
+        };
+
+        /* === Nav + Filters === */
+        $("#prev").onclick = () => { if (--state.month < 0) { state.month = 11; state.year--; } renderCalendar(); };
+        $("#next").onclick = () => { if (++state.month > 11) { state.month = 0; state.year++; } renderCalendar(); };
+        $("#todayBtn").onclick = () => { const t = new Date(); state.year = t.getFullYear(); state.month = t.getMonth(); renderCalendar(); };
+        $("#addQuick").onclick = () => openForm({ date: fmt(new Date()) });
+
+        $("#fAssign").onchange = (e) => { state.filters.assignment = e.target.checked; renderCalendar(); };
+        $("#fExam").onchange = (e) => { state.filters.exam = e.target.checked; renderCalendar(); };
+        $("#fAnn").onchange = (e) => { state.filters.announcement = e.target.checked; renderCalendar(); };
+
+        /* === Sample + Reset === */
+        $("#seed").onclick = () => {
+            if (!confirm("Load sample data? (This adds to your current items)")) return;
+            const base = new Date(state.year, state.month, 5);
+            const add = (d, type, title, course, desc, time = "") => ({
+                id: crypto.randomUUID(), type, date: fmt(new Date(+base + d * 86400000)),
+                title, course, desc, time
+            });
+            const samples = [
+                add(0, "announcement", "Monsoon semester begins", "Academics", "Check timetable on portal."),
+                add(1, "assignment", "DBMS Assignment 1", "DBMS", "Normalization problems"),
+                add(3, "exam", "COA Midterm", "COA", "Ch.1–3", "10:00"),
+                add(7, "assignment", "OS Lab Report", "OS", "Process scheduling"),
+                add(10, "exam", "Maths Quiz-2", "Maths", "Matrices", "09:00"),
+                add(12, "announcement", "Hackathon Registration closes", "", "Form on college site"),
+                add(15, "assignment", "DS Project Proposal", "DS", "Submit PDF on LMS")
+            ];
+            state.events.push(...samples); save(); renderCalendar();
+        };
+
+        $("#clearAll").onclick = () => {
+            if (!confirm("This will delete ALL saved items. Continue?")) return;
+            state.events = []; save(); renderCalendar();
+        };
+
+        $("#fAssign").checked = state.filters.assignment;
+        $("#fExam").checked = state.filters.exam;
+        $("#fAnn").checked = state.filters.announcement;
+        renderCalendar();
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Which issue does this PR close?
	•	Closes #74 

⸻

Rationale for this change

This change introduces an Academic Calendar UI so users can see upcoming assignments, exams, and announcements directly from the frontend.

⸻

What changes are included in this PR?
	•	Added new calendar view in templates/ using HTML, CSS, and JavaScript.
	•	Displayed events like assignments, exams, and announcements on the calendar.

⸻

Are these changes tested?
	•	Manually tested in the browser (Chrome).
	•	Verified that events render correctly on the calendar.
	•	No automated tests since this is frontend-only.

⸻

Are there any user-facing changes?
	•	 Yes. Users can now access an Academic Calendar page.
	•	They can view academic events visually on a calendar layout.
	•	No backend/database changes were made.

Screenshots?


https://github.com/user-attachments/assets/3527c624-4faf-47cb-b0c2-866c14bb7a0c

