### PR TITLE
Added hover effects on administrative setup cards

### DIFF
--- a/nouapp/templates/index.html
+++ b/nouapp/templates/index.html
@@ -14,6 +14,7 @@
     background-position: center;
     background-size: cover;
   }
+
   /*Home end*/
   /*headline*/
   /*aboutsection*/
@@ -23,10 +24,12 @@
     font-weight: bold;
     padding-left: 100px;
   }
+
   .about-section .row .col-sm-7 {
     padding-left: 75px;
     padding-top: 25px;
   }
+
   .about-section .row .col-sm-5 {
     padding-left: 80px;
     padding-top: 60px;
@@ -44,6 +47,7 @@
       padding-bottom: 25px;
       padding-right: 0px;
     }
+
     .about-section .row .col-sm-7 {
       padding-top: 0px;
       padding-left: 0px;
@@ -51,6 +55,7 @@
       align-content: center;
       font-size: 16px;
     }
+
     .about-section .row .col-sm-5 {
       padding-left: 0px;
       padding-top: 0px;
@@ -58,10 +63,12 @@
       padding-right: 0px;
       width: 100%;
     }
+
     .about-section .row .col-sm-5 img {
       width: 100%;
     }
   }
+
   /*gallery*/
   .gallery .row h3 {
     color: rgb(6, 6, 106);
@@ -69,14 +76,17 @@
     font-weight: bold;
     padding-left: 100px;
   }
+
   .gallery .row .col-sm-3 {
     padding-left: 40px;
     margin-top: 10px;
   }
+
   .gallery .row .col-sm-3 .card {
     width: 16rem;
     margin-left: 20px;
   }
+
   .gallery .row .col-sm-3 .card-body {
     background-color: rgb(6, 6, 106);
     color: white;
@@ -88,6 +98,7 @@
   .gallery .card {
     transition: transform 0.3s ease, box-shadow 0.3s ease;
   }
+
   .gallery .card:hover {
     transform: scale(1.05);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
@@ -102,6 +113,7 @@
       padding-bottom: 0px;
       padding-right: 0px;
     }
+
     .gallery .row .col-sm-3 {
       padding-left: 0px;
       margin-top: 10px;
@@ -109,11 +121,13 @@
       padding-right: 0px;
       align-content: center;
     }
+
     .gallery .row .col-sm-3 .card {
       width: auto;
       margin-left: 0px;
     }
   }
+
   /*administrative setup*/
   .team .row h3 {
     color: rgb(6, 6, 106);
@@ -121,12 +135,26 @@
     font-weight: bold;
     padding-left: 100px;
   }
+
   .team .row .col-sm-3 .card {
     width: 15rem;
     height: 20rem;
     margin-top: 30px;
     margin-left: 40px;
   }
+
+  .team .card {
+    transition: all 0.3s ease;
+    border-radius: 20px;
+  }
+
+  .team .card:hover {
+    transform: scale(1.05);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+  }
+
+
   @media (max-width: 600px) {
     .team .row h3 {
       color: rgb(6, 6, 106);
@@ -136,6 +164,7 @@
       padding-right: 0px;
       text-align: center;
     }
+
     .team .row .col-sm-3 .card {
       width: auto;
       height: auto;
@@ -143,6 +172,7 @@
       margin-left: 0px;
     }
   }
+
   /*contact section*/
   .contact-section .row h3 {
     color: rgb(6, 6, 106);
@@ -150,35 +180,41 @@
     font-weight: bold;
     padding-left: 100px;
   }
+
   .contact-section .row .col-sm-5 {
     position: relative;
     padding-top: 30px;
     padding-bottom: 10px;
     padding-left: 150px;
   }
+
   .contact-section .row .col-sm-5 img {
     width: 100%;
     height: 85%;
     align-content: center;
   }
+
   .contact-section .row .col-sm-6 {
     padding-top: 70px;
     padding-bottom: 10px;
     padding-right: 60px;
     padding-left: 50px;
   }
+
   .contact-section .row .col-sm-6 p {
     font-size: 17px;
     padding: 10px;
     color: white;
     font-family: open sans, sans-serif;
   }
+
   .contact-section .row .col-sm-6 h4 {
     font-size: 18px;
     padding: 8px;
     border: 1px solid grey;
     font-family: open sans, sans-serif;
   }
+
   @media (max-width: 600px) {
     .contact-section .row h3 {
       color: rgb(6, 6, 106);
@@ -188,12 +224,14 @@
       padding-right: 0px;
       text-align: center;
     }
+
     .contact-section .row .col-sm-5 {
       position: relative;
       padding-top: 30px;
       padding-bottom: 10px;
       padding-left: 0px;
     }
+
     .contact-section .row .col-sm-6 {
       padding-top: 10px;
       padding-bottom: 10px;
@@ -205,16 +243,13 @@
 <!--Home-->
 <div class="row">
   <section class="home">
-    <div
-      class="row"
-      style="
+    <div class="row" style="
         color: aliceblue;
         padding-top: 45vh;
         padding-left: 10px;
         font-weight: bolder;
         font-family: poppins, sans-serif;
-      "
-    >
+      ">
       <h1><u>Get Started</u></h1>
       <h2><b>From Our Content For Distance Learning</b></h2>
       <p style="font-family: poppins">
@@ -224,23 +259,14 @@
   </section>
 </div>
 <!--headline-->
-<div
-  class="row"
-  style="background-color: rgb(6, 6, 106); margin-top: 5px; margin-bottom: 5px"
->
-  <marquee
-    scrollamount="12"
-    onmousemove="this.stop()"
-    onmouseout="this.start()"
-  >
-    <p
-      style="
+<div class="row" style="background-color: rgb(6, 6, 106); margin-top: 5px; margin-bottom: 5px">
+  <marquee scrollamount="12" onmousemove="this.stop()" onmouseout="this.start()">
+    <p style="
         color: white;
         padding-top: 6px;
         font-family: poppins, sans-serif;
         font-weight: bold;
-      "
-    >
+      ">
       The portal is easy to access & highly user friendly for the students &
       study centres.
     </p>
@@ -290,11 +316,7 @@
     <div class="row" style="padding-top: 25px">
       <div class="col-sm-3">
         <div class="card" style="border-color: rgb(6, 6, 106)">
-          <img
-            class="card-img-top"
-            src="{% static 'images/registration.jpg' %}"
-            alt="Card image cap"
-          />
+          <img class="card-img-top" src="{% static 'images/registration.jpg' %}" alt="Card image cap" />
           <div class="card-body">
             <p class="card-text">
               <a href="{% url 'nouapp:login' %}" style="color: white">Login</a>
@@ -304,43 +326,27 @@
       </div>
       <div class="col-sm-3">
         <div class="card" style="border-color: rgb(6, 6, 106)">
-          <img
-            class="card-img-top"
-            src="{% static 'images/dashboard.jpg' %}"
-            alt="Card image cap"
-          />
+          <img class="card-img-top" src="{% static 'images/dashboard.jpg' %}" alt="Card image cap" />
           <div class="card-body">
             <p class="card-text">
-              <a href="{% url 'studentapp:studenthome' %}" style="color: white"
-                >Dashboard</a
-              >
+              <a href="{% url 'studentapp:studenthome' %}" style="color: white">Dashboard</a>
             </p>
           </div>
         </div>
       </div>
       <div class="col-sm-3">
         <div class="card" style="border-color: rgb(6, 6, 106)">
-          <img
-            class="card-img-top"
-            src="{% static 'images/online-courses.jpg' %}"
-            alt="Card image cap"
-          />
+          <img class="card-img-top" src="{% static 'images/online-courses.jpg' %}" alt="Card image cap" />
           <div class="card-body">
             <p class="card-text">
-              <a href="{% url 'studentapp:viewmat' %}" style="color: white"
-                >Self Learning Material</a
-              >
+              <a href="{% url 'studentapp:viewmat' %}" style="color: white">Self Learning Material</a>
             </p>
           </div>
         </div>
       </div>
       <div class="col-sm-3">
         <div class="card" style="border-color: rgb(6, 6, 106)">
-          <img
-            class="card-img-top"
-            src="{% static 'images/e-lectures.jpg' %}"
-            alt="Card image cap"
-          />
+          <img class="card-img-top" src="{% static 'images/e-lectures.jpg' %}" alt="Card image cap" />
           <div class="card-body">
             <p class="card-text">e-Books</p>
           </div>
@@ -351,11 +357,7 @@
     <div class="row" style="padding-top: 40px">
       <div class="col-sm-3">
         <div class="card" style="border-color: rgb(6, 6, 106)">
-          <img
-            class="card-img-top p-5"
-            src="{% static 'images/self-assessment.svg' %}"
-            alt="Card image cap"
-          />
+          <img class="card-img-top p-5" src="{% static 'images/self-assessment.svg' %}" alt="Card image cap" />
           <div class="card-body">
             <p class="card-text">Self Assessment Tools</p>
           </div>
@@ -363,48 +365,30 @@
       </div>
       <div class="col-sm-3">
         <div class="card" style="border-color: rgb(6, 6, 106)">
-          <img
-            class="card-img-top"
-            src="{% static 'images/performance.jpg' %}"
-            alt="Card image cap"
-          />
+          <img class="card-img-top" src="{% static 'images/performance.jpg' %}" alt="Card image cap" />
           <div class="card-body">
             <p class="card-text">
-              <a href="{% url 'studentapp:viewprofile' %}" style="color: white"
-                >Performance</a
-              >
+              <a href="{% url 'studentapp:viewprofile' %}" style="color: white">Performance</a>
             </p>
           </div>
         </div>
       </div>
       <div class="col-sm-3">
         <div class="card" style="border-color: rgb(6, 6, 106)">
-          <img
-            class="card-img-top"
-            src="{% static 'images/feedback.jpg' %}"
-            alt="Card image cap"
-          />
+          <img class="card-img-top" src="{% static 'images/feedback.jpg' %}" alt="Card image cap" />
           <div class="card-body">
             <p class="card-text">
-              <a href="{% url 'studentapp:response' %}" style="color: white"
-                >Feedback</a
-              >
+              <a href="{% url 'studentapp:response' %}" style="color: white">Feedback</a>
             </p>
           </div>
         </div>
       </div>
       <div class="col-sm-3">
         <div class="card" style="border-color: rgb(6, 6, 106)">
-          <img
-            class="card-img-top"
-            src="{% static 'images/course-catlog.jpg' %}"
-            alt="Card image cap"
-          />
+          <img class="card-img-top" src="{% static 'images/course-catlog.jpg' %}" alt="Card image cap" />
           <div class="card-body">
             <p class="card-text">
-              <a href="{% url 'nouapp:courses' %}" style="color: white"
-                >Course-Catalogue</a
-              >
+              <a href="{% url 'nouapp:courses' %}" style="color: white">Course-Catalogue</a>
             </p>
           </div>
         </div>
@@ -422,19 +406,10 @@
       <div class="row">
         <div class="col-sm-3">
           <div class="card">
-            <img
-              class="card-img-top p-4"
-              src="{% static 'images/vc.jpg' %}"
-              alt="Card image cap"
-              width="auto"
-              height="250px"
-              style="border-radius: 50%"
-            />
+            <img class="card-img-top p-4" src="{% static 'images/vc.jpg' %}" alt="Card image cap" width="auto"
+              height="250px" style="border-radius: 50%" />
             <div class="card-body" style="text-align: center">
-              <h6
-                class="card-text"
-                style="color: rgb(6, 6, 106); font-weight: bold"
-              >
+              <h6 class="card-text" style="color: rgb(6, 6, 106); font-weight: bold">
                 Prof. (Dr.) K. C. Sinha
               </h6>
               <p class="card-text">VICE CHANCELLOR</p>
@@ -443,19 +418,10 @@
         </div>
         <div class="col-sm-3">
           <div class="card">
-            <img
-              class="card-img-top p-4"
-              src="{% static 'images/pvc.jpg' %}"
-              alt="Card image cap"
-              width="auto"
-              height="250px"
-              style="border-radius: 50%"
-            />
+            <img class="card-img-top p-4" src="{% static 'images/pvc.jpg' %}" alt="Card image cap" width="auto"
+              height="250px" style="border-radius: 50%" />
             <div class="card-body" style="text-align: center">
-              <h6
-                class="card-text"
-                style="color: rgb(6, 6, 106); font-weight: bold"
-              >
+              <h6 class="card-text" style="color: rgb(6, 6, 106); font-weight: bold">
                 Prof. (Dr.) Sanjoy Kumar
               </h6>
               <p class="card-text">PRO VICE CHANCELLOR</p>
@@ -464,19 +430,10 @@
         </div>
         <div class="col-sm-3">
           <div class="card">
-            <img
-              class="card-img-top p-4"
-              src="{% static 'images/registrar1.jpeg' %}"
-              alt="Card image cap"
-              width="auto"
-              height="250px"
-              style="border-radius: 50%"
-            />
+            <img class="card-img-top p-4" src="{% static 'images/registrar1.jpeg' %}" alt="Card image cap" width="auto"
+              height="250px" style="border-radius: 50%" />
             <div class="card-body" style="text-align: center">
-              <h6
-                class="card-text"
-                style="color: rgb(6, 6, 106); font-weight: bold"
-              >
+              <h6 class="card-text" style="color: rgb(6, 6, 106); font-weight: bold">
                 Dr. Md. Habibur Rahman
               </h6>
               <p class="card-text">REGISTRAR</p>
@@ -485,19 +442,10 @@
         </div>
         <div class="col-sm-3">
           <div class="card">
-            <img
-              class="card-img-top p-4"
-              src="{% static 'images/examreg.jpg' %}"
-              alt="Card image cap"
-              width="auto"
-              height="250px"
-              style="border-radius: 50%"
-            />
+            <img class="card-img-top p-4" src="{% static 'images/examreg.jpg' %}" alt="Card image cap" width="auto"
+              height="250px" style="border-radius: 50%" />
             <div class="card-body" style="text-align: center">
-              <h6
-                class="card-text"
-                style="color: rgb(6, 6, 106); font-weight: bold"
-              >
+              <h6 class="card-text" style="color: rgb(6, 6, 106); font-weight: bold">
                 Dr. Neelam Kumari
               </h6>
               <p class="card-text">REGISTRAR (Exam)</p>
@@ -525,18 +473,18 @@
           maintenance of student information and issues faced.
         </p>
         <br />
-        <a
-          ><h4>
+        <a>
+          <h4>
             <i class="fa fa-phone" style="color: rgb(6, 6, 106)"></i> +91
             7080102007
-          </h4></a
-        ><br />
-        <a
-          ><h4>
+          </h4>
+        </a><br />
+        <a>
+          <h4>
             <i class="fa fa-envelope" style="color: rgb(6, 6, 106)"></i>
             nouegyanhelp@gmail.com
-          </h4></a
-        ><br />
+          </h4>
+        </a><br />
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #97 

## Rationale for this change
The administrative setup cards currently have no hover effect, making them feel flat and less interactive.  
Adding a scale + shadow hover effect improves user experience by providing clear visual feedback when hovering over the cards.

## What changes are included in this PR?

- Scoped CSS hover effect for `.team .card`:
  - Slight scale-up (`transform: scale(1.05)`)
  - Smooth transition
  - Box-shadow for depth
  - Pointer cursor on hover  
- Applied only to cards under the **Administrative Setup** section (`.team .card`) to avoid affecting other Bootstrap cards on the site.
- 
## Are these changes tested?
- Verified locally in the browser:  
  - Cards scale smoothly with shadow on hover.  
  - Only Administrative Setup cards are affected.  
  - No visual side effects on other pages/components.  
## Are there any user-facing changes?
- Yes.  
  - Users hovering over Administrative Setup cards will now see an interactive effect (scale + shadow).  
  - This makes the section more engaging without altering layout or functionality.
<img width="867" height="808" alt="Screenshot (95)" src="https://github.com/user-attachments/assets/f84160a6-ae9e-4576-a20a-9a50046c3185" />
